### PR TITLE
Use HTTPS for the creativecommons website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1374,7 +1374,7 @@ $ ip -6 rule show
       </div>
       <div class="copyright">
         <span>Copyright &copy; Daniil Baturin &lt;daniil at baturin dot org&gt; 2013, 2015.</span> <br /><br />
-        <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />
         <br />
         <span>Last modified: 2015 Oct 19.</span>
       </div>


### PR DESCRIPTION
Deploying the site under HTTPS leads to mixed content warnings from browsers. This fixes it.
